### PR TITLE
libpolyhedron: (unistd) getpid syscall

### DIFF
--- a/hexahedron/include/kernel/task/syscall.h
+++ b/hexahedron/include/kernel/task/syscall.h
@@ -86,5 +86,6 @@ long sys_getcwd(char *buf, size_t size);
 long sys_chdir(const char *path);
 long sys_fchdir(int fd);
 long sys_uname(struct utsname *buf);
+pid_t sys_getpid();
 
 #endif

--- a/hexahedron/task/syscall.c
+++ b/hexahedron/task/syscall.c
@@ -49,7 +49,8 @@ static syscall_func_t syscall_table[] = {
     [SYS_GETCWD]        = (syscall_func_t)(uintptr_t)sys_getcwd,
     [SYS_CHDIR]         = (syscall_func_t)(uintptr_t)sys_chdir,
     [SYS_FCHDIR]        = (syscall_func_t)(uintptr_t)sys_fchdir,
-    [SYS_UNAME]         = (syscall_func_t)(uintptr_t)sys_uname
+    [SYS_UNAME]         = (syscall_func_t)(uintptr_t)sys_uname,
+    [SYS_GETPID]        = (syscall_func_t)(uintptr_t)sys_getpid
 };
 
 /* Unimplemented system call */
@@ -568,4 +569,8 @@ long sys_uname(struct utsname *buf) {
     snprintf(buf->machine, LIBPOLYHEDRON_UTSNAME_LENGTH, "%s", __kernel_architecture);
 
     return 0;
+}
+
+pid_t sys_getpid() {
+    return current_cpu->current_process->pid;
 }

--- a/libpolyhedron/arch/i386/include/sys/syscall.h
+++ b/libpolyhedron/arch/i386/include/sys/syscall.h
@@ -45,6 +45,7 @@ _Begin_C_Header
 #define SYS_CHDIR           29
 #define SYS_FCHDIR          30
 #define SYS_UNAME           31
+#define SYS_GETPID          32
 
 /* Syscall macros */
 #define DEFINE_SYSCALL0(name, num) \

--- a/libpolyhedron/arch/x86_64/include/sys/syscall.h
+++ b/libpolyhedron/arch/x86_64/include/sys/syscall.h
@@ -45,6 +45,7 @@ _Begin_C_Header
 #define SYS_CHDIR           29
 #define SYS_FCHDIR          30
 #define SYS_UNAME           31
+#define SYS_GETPID          32
 
 /* Syscall macros */
 #define DEFINE_SYSCALL0(name, num) \

--- a/libpolyhedron/include/sys/syscall_defs.h
+++ b/libpolyhedron/include/sys/syscall_defs.h
@@ -64,6 +64,7 @@ DECLARE_SYSCALL2(getcwd, char*, size_t);
 DECLARE_SYSCALL1(chdir, const char*);
 DECLARE_SYSCALL1(fchdir, int);
 DECLARE_SYSCALL1(uname, struct utsname*);
+DECLARE_SYSCALL0(getpid);
 
 #endif
 

--- a/libpolyhedron/include/unistd.h
+++ b/libpolyhedron/include/unistd.h
@@ -60,6 +60,7 @@ pid_t waitpid(pid_t pid, int *wstatus, int options);
 char *getcwd(char *buf, size_t size);
 int chdir(const char *path);
 int fchdir(int fd);
+pid_t getpid();
 
 /* STUBS */
 int mkdir(const char *pathname, mode_t mode);

--- a/libpolyhedron/unistd/getpid.c
+++ b/libpolyhedron/unistd/getpid.c
@@ -1,0 +1,22 @@
+/**
+ * @file libpolyhedron/unistd/getpid.c
+ * @brief getpid syscall
+ * 
+ * 
+ * @copyright
+ * This file is part of the Hexahedron kernel, which is apart of the Ethereal Operating System.
+ * It is released under the terms of the BSD 3-clause license.
+ * Please see the LICENSE file in the main repository for more details.
+ * 
+ * Copyright (C) 2024 Samuel Stuart
+ * 
+ * @author Rubyboat
+ */
+
+#include <unistd.h>
+
+DEFINE_SYSCALL0(getpid, SYS_GETPID);
+
+pid_t getpid() {
+    return __syscall_getpid();
+}


### PR DESCRIPTION
Adds the getpid syscall. Currently is more-or-less useless considering you cant really get a process from a pid.

![image](https://github.com/user-attachments/assets/60470b75-2b21-471c-90e8-3606e1cb0231)
I made a small edit to the terminal to make sure all is running well and that looks correct to me.